### PR TITLE
Don’t run tests on Node 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ language: node_js
 node_js:
   - node
   - "8"
-  - "6"
 
 cache:
   yarn: true
@@ -18,15 +17,9 @@ env:
     - JOB=test AST_COMPARE=1
 
 matrix:
-  fast_finish: true
   include:
     - node_js: "node"
       env: JOB=lint
-  # Our test fail with a segfault in node 6
-  # (see https://github.com/prettier/prettier/issues/3457)
-  # To prevent making our Travis run useless, mark Node 6 as allowed to fail.
-  allow_failures:
-    - node_js: "6"
 
 install:
   - yarn install


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

They’re currently segfaulting so we ignore them. Therefore there’s no point in even running this job until #3457 is fixed since there isn’t a way for it to signal that something has gone wrong on Node 6 other than the segfault.

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
